### PR TITLE
Configure Knope

### DIFF
--- a/.changeset/configure_knope.md
+++ b/.changeset/configure_knope.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Configure Knope

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -1,0 +1,29 @@
+on:
+  push:
+    branches: [main]
+
+name: Prepare Release PR
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+
+jobs:
+  prepare-release:
+    if: "!contains(github.event.head_commit.message, 'chore: prepare release')" # Skip merges from releases
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+      - name: Configure Git
+        run: |
+          git config --global user.name GitHub Actions
+          git config user.email github-actions@github.com
+      - uses: knope-dev/action@v2.1.0
+        with:
+          version: 0.18.3
+      - run: knope prepare-release --verbose
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,91 @@
+name: Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  build-artifacts:
+    if: github.head_ref == 'release' && github.event.pull_request.merged == true
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+    env:
+      package_name: cli-template
+
+    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.target }}
+
+    steps:
+      - uses: actions/checkout@v4.2.2
+      - uses: Swatinem/rust-cache@v2.7.7
+      - name: Install host target
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Build
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Set Archive Name (Non-Windows)
+        id: archive
+        run: echo "archive_name=cli-template-${{ matrix.target }}" >> $GITHUB_ENV
+
+      - name: Set Archive Name (Windows)
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: echo "archive_name=cli-template-${{ matrix.target }}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Create Archive Folder
+        run: mkdir ${{ env.archive_name }}
+
+      - name: Copy Unix Artifact
+        if: ${{ matrix.os != 'windows-latest' }}
+        run: cp target/${{ matrix.target }}/release/cli-template ${{ env.archive_name }}
+
+      - name: Copy Windows Artifact
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: cp target/${{ matrix.target }}/release/cli-template.exe ${{ env.archive_name }}
+
+      - name: Create Tar Archive
+        run: tar -czf ${{ env.archive_name }}.tgz ${{ env.archive_name }}
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4.6.0
+        with:
+          name: ${{ matrix.target }}
+          path: ${{ env.archive_name }}.tgz
+          if-no-files-found: error
+
+  release:
+    needs: [build-artifacts]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.2
+      - uses: actions/download-artifact@v4.1.8
+        with:
+          path: artifacts
+          merge-multiple: true
+      - uses: knope-dev/action@v2.1.0
+        with:
+          version: 0.18.3
+      - run: knope release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # publish-crate:
+  #   needs: [release]
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4.2.2
+  #     - uses: Swatinem/rust-cache@v2.7.7
+  #     - uses: katyo/publish-crates@v2
+  #       with:
+  #         registry-token: ${{ secrets.CARGO_TOKEN }}

--- a/knope.toml
+++ b/knope.toml
@@ -1,0 +1,51 @@
+[package]
+versioned_files = ["Cargo.toml", "Cargo.lock"]
+changelog = "CHANGELOG.md"
+assets = "artifacts/*"
+
+[[workflows]]
+name = "changeset"
+
+[[workflows.steps]]
+type = "CreateChangeFile"
+
+[[workflows]]
+name = "prepare-release"
+
+[[workflows.steps]]
+type = "Command"
+command = "git switch -c release"
+
+[[workflows.steps]]
+type = "PrepareRelease"
+
+[[workflows.steps]]
+type = "Command"
+command = "git commit -m \"chore: prepare release $version\""
+variables = { "$version" = "Version" }
+
+[[workflows.steps]]
+type = "Command"
+command = "git push --force --set-upstream origin release"
+
+[[workflows.steps]]
+type = "CreatePullRequest"
+base = "main"
+
+[workflows.steps.title]
+template = "chore: prepare release $version"
+variables = { "$version" = "Version" }
+
+[workflows.steps.body]
+template = "This PR was created by Knope. Merging it will create a new release\n\n$changelog"
+variables = { "$changelog" = "ChangelogEntry" }
+
+[[workflows]]
+name = "release"
+
+[[workflows.steps]]
+type = "Release"
+
+[github]
+owner = "mootoday"
+repo = "cli-template"


### PR DESCRIPTION
This automates the process of building and releasing the CLI binary with [Knope](https://knope.tech/).

To make the release process work:
1. In your GitHub repo settings, navigate to **Actions** -> **General**
2. In the **Workflow permissions** section, enable the following:
    * Read and write permissions
    * Allow GitHub Actions to create and approve pull requests